### PR TITLE
[RBAC] Fix permissions on some of the endpoints

### DIFF
--- a/src/aap_eda/api/views/activation.py
+++ b/src/aap_eda/api/views/activation.py
@@ -187,7 +187,7 @@ class ActivationViewSet(
     )
     @action(methods=["post"], detail=True, rbac_action=Action.ENABLE)
     def enable(self, request, pk):
-        activation = get_object_or_404(models.Activation, pk=pk)
+        activation = get_object_or_404(self.get_queryset(), pk=pk)
 
         if activation.is_enabled:
             return Response(status=status.HTTP_204_NO_CONTENT)
@@ -241,7 +241,7 @@ class ActivationViewSet(
     )
     @action(methods=["post"], detail=True, rbac_action=Action.DISABLE)
     def disable(self, request, pk):
-        activation = get_object_or_404(models.Activation, pk=pk)
+        activation = get_object_or_404(self.get_queryset(), pk=pk)
 
         self._check_deleting(activation)
 
@@ -271,7 +271,7 @@ class ActivationViewSet(
     )
     @action(methods=["post"], detail=True, rbac_action=Action.RESTART)
     def restart(self, request, pk):
-        activation = get_object_or_404(models.Activation, pk=pk)
+        activation = get_object_or_404(self.get_queryset(), pk=pk)
 
         self._check_deleting(activation)
 
@@ -367,7 +367,7 @@ class ActivationInstanceViewSet(
         url_path="(?P<id>[^/.]+)/logs",
     )
     def logs(self, request, id):
-        instance_exists = models.RulebookProcess.objects.filter(pk=id).exists()
+        instance_exists = self.get_queryset().filter(pk=id).exists()
         if not instance_exists:
             raise api_exc.NotFound(
                 code=status.HTTP_404_NOT_FOUND,

--- a/src/aap_eda/api/views/credential.py
+++ b/src/aap_eda/api/views/credential.py
@@ -124,7 +124,7 @@ class CredentialViewSet(
         },
     )
     def retrieve(self, request, pk: int):
-        queryset = models.Credential.access_qs(request.user).exclude(
+        queryset = self.get_queryset().exclude(
             credential_type=CredentialType.VAULT,
             vault_identifier=EDA_SERVER_VAULT_LABEL,
         )
@@ -141,7 +141,7 @@ class CredentialViewSet(
         },
     )
     def list(self, request):
-        credentials = models.Credential.objects.exclude(
+        credentials = self.get_queryset().exclude(
             credential_type=CredentialType.VAULT,
             vault_identifier=EDA_SERVER_VAULT_LABEL,
         )

--- a/src/aap_eda/api/views/project.py
+++ b/src/aap_eda/api/views/project.py
@@ -184,7 +184,7 @@ class ProjectViewSet(
         },
     )
     def partial_update(self, request, pk):
-        project = get_object_or_404(models.Project, pk=pk)
+        project = get_object_or_404(self.get_queryset(), pk=pk)
         serializer = serializers.ProjectUpdateRequestSerializer(
             instance=project, data=request.data, partial=True
         )
@@ -235,7 +235,7 @@ class ProjectViewSet(
     @transaction.atomic
     def sync(self, request, pk):
         try:
-            project = models.Project.objects.select_for_update().get(pk=pk)
+            project = self.get_queryset().select_for_update().get(pk=pk)
         except models.Project.DoesNotExist:
             raise api_exc.NotFound
 

--- a/src/aap_eda/api/views/rulebook.py
+++ b/src/aap_eda/api/views/rulebook.py
@@ -110,7 +110,7 @@ class RulebookViewSet(
     )
     @action(detail=True, rbac_action=Action.READ)
     def json(self, request, pk):
-        rulebook = get_object_or_404(models.Rulebook, pk=pk)
+        rulebook = get_object_or_404(self.get_queryset(), pk=pk)
         data = serializers.RulebookSerializer(rulebook).data
         data["rulesets"] = yaml.safe_load(data["rulesets"])
 
@@ -262,7 +262,7 @@ class AuditRuleViewSet(
         url_path="(?P<id>[^/.]+)/actions",
     )
     def actions(self, _request, id):
-        audit_rule = get_object_or_404(models.AuditRule, id=id)
+        audit_rule = get_object_or_404(self.get_queryset(), id=id)
         audit_actions = models.AuditAction.objects.filter(
             audit_rule=audit_rule,
             rule_fired_at=audit_rule.fired_at,
@@ -303,7 +303,7 @@ class AuditRuleViewSet(
         url_path="(?P<id>[^/.]+)/events",
     )
     def events(self, _request, id):
-        audit_rule = get_object_or_404(models.AuditRule, id=id)
+        audit_rule = get_object_or_404(self.get_queryset(), id=id)
         audit_actions = models.AuditAction.objects.filter(
             audit_rule=audit_rule,
             rule_fired_at=audit_rule.fired_at,

--- a/src/aap_eda/core/migrations/0023_dab_rbac.py
+++ b/src/aap_eda/core/migrations/0023_dab_rbac.py
@@ -2,14 +2,18 @@
 
 from django.db import migrations, models
 
-from aap_eda.core.migrations._dab_rbac import create_permissions_as_operation, migrate_roles_to_dab, remove_dab_models
+from aap_eda.core.migrations._dab_rbac import (
+    create_permissions_as_operation,
+    migrate_roles_to_dab,
+    remove_dab_models,
+)
 
 
 class Migration(migrations.Migration):
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
         ("core", "0022_add_default_organization"),
-        ("dab_rbac", "__first__")
+        ("dab_rbac", "__first__"),
     ]
 
     operations = [
@@ -22,13 +26,6 @@ class Migration(migrations.Migration):
                     ("disable_activation", "Can disable an activation"),
                     ("restart_activation", "Can restart an activation"),
                 ],
-            },
-        ),
-        migrations.AlterModelOptions(
-            name="auditevent",
-            options={
-                "default_permissions": ("view",),
-                "ordering": ("-received_at", "-rule_fired_at"),
             },
         ),
         migrations.AlterModelOptions(
@@ -76,9 +73,7 @@ class Migration(migrations.Migration):
         migrations.RunPython(
             create_permissions_as_operation, migrations.RunPython.noop
         ),
-        migrations.RunPython(
-            migrate_roles_to_dab, remove_dab_models
-        ),
+        migrations.RunPython(migrate_roles_to_dab, remove_dab_models),
         # Temporary - allow creating a user without providing role
         # as long as this relationship refers to the old, now unused, roles
         migrations.AlterField(

--- a/src/aap_eda/core/models/__init__.py
+++ b/src/aap_eda/core/models/__init__.py
@@ -15,7 +15,7 @@
 from ansible_base.rbac import permission_registry
 
 from .activation import Activation, RulebookProcess, RulebookProcessLog
-from .auth import Permission, DABPermission, Role
+from .auth import DABPermission, Permission, Role
 from .credential import Credential
 from .decision_environment import DecisionEnvironment
 from .event_stream import EventStream
@@ -81,11 +81,10 @@ permission_registry.register(
     DecisionEnvironment,
     RulebookProcess,
     AuditRule,
-    AuditEvent,
     Project,
     ExtraVar,
     Rulebook,
-    parent_field_name='organization',
+    parent_field_name="organization",
 )
 permission_registry.register(
     EventStream,

--- a/src/aap_eda/core/models/rulebook.py
+++ b/src/aap_eda/core/models/rulebook.py
@@ -102,7 +102,7 @@ class AuditRule(models.Model):
             models.Index(fields=["fired_at"], name="ix_audit_rule_fired_at"),
         ]
         ordering = ("-fired_at",)
-        default_permissions = ('view',)
+        default_permissions = ("view",)
 
     name = models.TextField(null=False)
     status = models.TextField()
@@ -160,7 +160,6 @@ class AuditEvent(models.Model):
     class Meta:
         db_table = "core_audit_event"
         ordering = ("-received_at", "-rule_fired_at")
-        default_permissions = ('view',)
 
     id = models.UUIDField(primary_key=True)
     source_name = models.TextField()


### PR DESCRIPTION
Fixed broken permissions for the following endpoints:
- Activation enable/disable/restart 
- Activation Instance Logs 
- Audit Rule Actions list 
- Audit Rule Events list 
- Credentials list 
- Project patch
- Project sync 
- Rulebook/json retrieve

NOTE: I removed Audit Action from permission registry as they are accessed only through Audit Rule, we first check if the user can access an Audit Rule then we show related Audit Action and Audit Events. Thus, I think it is redundant to set permissions for them.  